### PR TITLE
refactor(sage_blog): replace `is_active` with `is_published` in models, admins and repositories

### DIFF
--- a/sage_blog/admin/category.py
+++ b/sage_blog/admin/category.py
@@ -18,8 +18,8 @@ class PostCategoryAdmin(admin.ModelAdmin):
 
     # Display settings
     admin_priority = 1
-    list_display = ("title", "slug", "is_active", "modified_at")
-    list_filter = (PostsStatusFilter, "is_active")
+    list_display = ("title", "slug", "is_published", "published_posts_count", "modified_at")
+    list_filter = (PostsStatusFilter, "is_published")
     search_fields = ("title",)
     date_hierarchy = "created_at"
     ordering = ("title",)
@@ -27,7 +27,7 @@ class PostCategoryAdmin(admin.ModelAdmin):
 
     # Form layout customization
     fieldsets = (
-        (None, {"fields": ("title", "slug", "is_active")}),
+        (None, {"fields": ("title", "slug", "is_published")}),
         (_("Timestamps"), {"fields": ("created_at", "modified_at")}),
     )
     readonly_fields = ("created_at", "modified_at", "slug")
@@ -35,5 +35,9 @@ class PostCategoryAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         queryset = queryset.join_posts()
-        # queryset = queryset.prefetch_related("posts")
         return queryset
+
+    @admin.display(description=_("Published Posts"))
+    def published_posts_count(self, obj):
+        # Annotate the count of published posts directly when accessed
+        return obj.posts.filter(is_published=True).count()

--- a/sage_blog/admin/filters/__init__.py
+++ b/sage_blog/admin/filters/__init__.py
@@ -1,1 +1,1 @@
-from .post import PostsStatusFilter
+from .category import PostsStatusFilter

--- a/sage_blog/admin/filters/category.py
+++ b/sage_blog/admin/filters/category.py
@@ -9,12 +9,12 @@ class PostsStatusFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         return [
             ("no_posts", _("No Posts")),
-            ("inactive_posts", _("Only Inactive Posts")),
+            ("published_posts", _("Only With Published Posts")),
         ]
 
     def queryset(self, request, queryset):
         if self.value() == "no_posts":
             return queryset.filter(posts__isnull=True)
-        elif self.value() == "inactive_posts":
-            return queryset.filter_active_posts().distinct()
+        elif self.value() == "published_posts":
+            return queryset.filter_published_posts().distinct()
         return queryset

--- a/sage_blog/admin/post.py
+++ b/sage_blog/admin/post.py
@@ -26,14 +26,14 @@ class PostAdmin(admin.ModelAdmin, AdminImageMixin):
     # Display settings
     list_display = (
         "title",
-        "is_active",
+        "is_published",
         "category",
         "get_tags",
         "get_summary",
         "published_at",
         "modified_at",
     )
-    list_filter = ("is_active", "category", "published_at", "modified_at")
+    list_filter = ("is_published", "category", "published_at", "modified_at")
     search_fields = (
         "title",
         "slug",
@@ -49,7 +49,7 @@ class PostAdmin(admin.ModelAdmin, AdminImageMixin):
     ordering = ("-published_at",)
     readonly_fields = ("created_at", "modified_at", "slug")
     fieldsets = (
-        ("Basic Information", {"fields": ("title", "slug", "category", "is_active")}),
+        ("Basic Information", {"fields": ("title", "slug", "category", "is_published")}),
         (
             "Content Details",
             {

--- a/sage_blog/admin/tag.py
+++ b/sage_blog/admin/tag.py
@@ -15,7 +15,7 @@ class PostTagAdmin(admin.ModelAdmin):
     """
 
     admin_priority = 3
-    list_display = ("title", "slug", "is_active", "modified_at")
+    list_display = ("title", "slug", "is_published", "modified_at")
     list_filter = ("created_at", "modified_at")
     search_fields = ("title",)
     date_hierarchy = "created_at"
@@ -23,7 +23,7 @@ class PostTagAdmin(admin.ModelAdmin):
     ordering = ("title",)
 
     fieldsets = (
-        (None, {"fields": ("title", "slug", "is_active")}),
+        (None, {"fields": ("title", "slug", "is_published")}),
         (_("Timestamps"), {"fields": ("created_at", "modified_at")}),
     )
     readonly_fields = ("created_at", "modified_at", "slug")

--- a/sage_blog/models/category.py
+++ b/sage_blog/models/category.py
@@ -13,15 +13,14 @@ class PostCategory(TitleSlugMixin, TimeStampMixin):
     Post Category
     """
 
-    is_active = models.BooleanField(
-        _("Is Active"),
+    is_published = models.BooleanField(
+        _("Is Published"),
         default=True,
         help_text=_(
-            "Indicate whether this category is currently active and should be displayed "
-            "publicly. Deactivate to hide the category from public view without deleting "
-            "it."
+            "Indicate whether this category is currently published and should be displayed "
+            "to all users. If unpublished, only staff users can view the category."
         ),
-        db_comment="Indicates if the category is active (true) or hidden from public view (false).",
+        db_comment="Indicates if the category is published (true) or hidden from non-staff users (false).",
     )
 
     objects = CategoryDataAccessLayer()

--- a/sage_blog/models/post.py
+++ b/sage_blog/models/post.py
@@ -32,15 +32,14 @@ class Post(
     Represents a blog post in the system.
     """
 
-    is_active = models.BooleanField(
-        _("Is Active"),
+    is_published = models.BooleanField(
+        _("Is Published"),
         default=True,
         help_text=_(
-            "Indicate whether this post is currently active and should be displayed "
-            "publicly. Deactivate to hide the post from public view without deleting "
-            "it."
+            "Indicate whether this post is currently published and should be displayed "
+            "to all users. If unpublished, only staff users can view the post."
         ),
-        db_comment="Indicates if the post is active (true) or hidden from public view (false).",
+        db_comment="Indicates if the post is published (true) or hidden from non-staff users (false).",
     )
 
     summary = models.CharField(

--- a/sage_blog/models/tag.py
+++ b/sage_blog/models/tag.py
@@ -13,15 +13,14 @@ class PostTag(TitleSlugMixin, TimeStampMixin):
     Post Tag Model
     """
 
-    is_active = models.BooleanField(
-        _("Is Active"),
+    is_published = models.BooleanField(
+        _("Is Published"),
         default=True,
         help_text=_(
-            "Indicate whether this tag is currently active and should be displayed "
-            "publicly. Deactivate to hide the tag from public view without deleting "
-            "it."
+            "Indicate whether this tag is currently published and should be displayed "
+            "to all users. If unpublished, only staff users can view the tag."
         ),
-        db_comment="Indicates if the tag is active (true) or hidden from public view (false).",
+        db_comment="Indicates if the tag is published (true) or hidden from non-staff users (false).",
     )
 
     objects = TagDataAccessLayer()

--- a/sage_blog/repository/generator/data_generator.py
+++ b/sage_blog/repository/generator/data_generator.py
@@ -64,7 +64,7 @@ class DataGeneratorLayer(BaseDataGenerator):
             PostTag(
                 title=word,
                 slug=slugify(word),
-                is_active=self.get_random_boolean()
+                is_published=self.get_random_boolean()
                 )
             for i in tqdm(range(total), disable=disable_progress_bar, colour="#b8835c")
             if (word := self.get_random_words(3))
@@ -102,7 +102,7 @@ class DataGeneratorLayer(BaseDataGenerator):
             PostCategory(
                 title=word,
                 slug=slugify(word),
-                is_active=self.get_random_boolean()
+                is_published=self.get_random_boolean()
                 )
             for i in tqdm(range(total), disable=disable_progress_bar, colour="#b8835c")
             if (word := self.get_random_words(3))
@@ -159,7 +159,7 @@ class DataGeneratorLayer(BaseDataGenerator):
                 summary=self.text.sentence()[:125],
                 description=self.text.text(5),
                 category=self.get_random_object(post_categories),
-                is_active=self.get_random_boolean(),
+                is_published=self.get_random_boolean(),
                 alternate_text=self.get_random_sentence()[:109],
                 picture=SimpleUploadedFile(
                     name=img_name,

--- a/sage_blog/repository/managers/category.py
+++ b/sage_blog/repository/managers/category.py
@@ -28,17 +28,17 @@ class CategoryDataAccessLayer(Manager):
         """
         return self.get_queryset().annotate_total_posts()
 
-    def get_actives(self, is_active=True):
+    def filter_published(self, is_published=True):
         """
         Filters categories based on their active status.
         """
-        return self.get_queryset().get_actives(is_active)
+        return self.get_queryset().filter_published(is_published)
 
-    def filter_active_posts(self, is_active=True):
+    def filter_published_posts(self, is_published=True):
         """
         Prefetches related posts for each category in the queryset.
         """
-        return self.get_queryset().filter_active_posts(is_active)
+        return self.get_queryset().filter_published_posts(is_published)
 
     def join_posts(self):
         """
@@ -46,11 +46,11 @@ class CategoryDataAccessLayer(Manager):
         """
         return self.get_queryset().join_posts()
 
-    def exclude_inactive_posts(self) -> "QuerySet":
+    def exclude_unpublished_posts(self) -> "QuerySet":
         """
         Excludes categories that are only associated with inactive or discontinued posts.
         """
-        return self.get_queryset().exclude_inactive_posts()
+        return self.get_queryset().exclude_unpublished_posts()
 
     def filter_recent_categories(self, num_categories=5, obj=None):
         """

--- a/sage_blog/repository/managers/post.py
+++ b/sage_blog/repository/managers/post.py
@@ -17,11 +17,11 @@ class PostDataAccessLayer(Manager):
         """
         return PostQuerySet(self.model, using=self._db)
 
-    def filter_actives(self, is_active=True):
+    def filter_actives(self, is_published=True):
         """
         Returns a queryset of posts filtered by their active status.
         """
-        return self.get_queryset().filter_actives(is_active)
+        return self.get_queryset().filter_actives(is_published)
 
     def filter_recent_posts(self, num_posts=5):
         """

--- a/sage_blog/repository/managers/tag.py
+++ b/sage_blog/repository/managers/tag.py
@@ -93,11 +93,11 @@ class TagDataAccessLayer(Manager):
         """
         return self.get_queryset().filter_by_posts_category(category_name)
 
-    def exclude_inactive_posts(self) -> QuerySet:
+    def exclude_unpublished_posts(self) -> QuerySet:
         """
         Excludes tags that are only associated with inactive or discontinued posts.
         """
-        return self.get_queryset().exclude_inactive_posts()
+        return self.get_queryset().exclude_unpublished_posts()
 
     def sort_by_popularity(self) -> QuerySet:
         """

--- a/sage_blog/repository/queryset/category.py
+++ b/sage_blog/repository/queryset/category.py
@@ -15,38 +15,38 @@ class CategoryQuerySet(QuerySet):
         an additional attribute 'total_posts' for each category object, which
         indicates the count of posts in that category.
         """
-        active_posts = self.filter_active_posts()
-        qs = active_posts.annotate(total_posts=Count("posts"))
+        published_posts = self.filter_published_posts()
+        qs = published_posts.annotate(total_posts=Count("posts"))
         return qs
 
-    def get_actives(self, is_active: bool = True):
+    def filter_published(self, is_published: bool = True):
         """
-        Filters categories based on their active status.
+        Filters categories based on their published status.
         """
-        qs = self.filter(is_active=is_active)
+        qs = self.filter(is_published=is_published)
         return qs
 
-    def filter_active_posts(self, is_active: bool=True):
+    def filter_published_posts(self, is_published: bool=True):
         """
         Prefetches related posts for each category in the queryset.
         """
-        active_posts_condition = Q(posts__is_active=is_active)
-        actives = self.get_actives()
-        qs = actives.filter(active_posts_condition)
+        published_posts_condition = Q(posts__is_published=is_published)
+        published = self.filter_published()
+        qs = published.filter(published_posts_condition)
         return qs
 
     def join_posts(self):
         """
-        Excludes categories that are only associated with inactive or discontinued posts.
+        Excludes categories that are only associated with inpublished or discontinued posts.
         """
         qs = self.prefetch_related("posts")
         return qs
 
-    def exclude_inactive_posts(self) -> QuerySet:
+    def exclude_unpublished_posts(self) -> QuerySet:
         """
-        Excludes categories that are only associated with inactive or discontinued posts.
+        Excludes categories that are only associated with inpublished or discontinued posts.
         """
-        qs = self.filter(posts__is_active=True)
+        qs = self.filter(posts__is_published=True)
         return qs
 
     def filter_recent_categories(self, num_categories=5, obj=None):

--- a/sage_blog/repository/queryset/post.py
+++ b/sage_blog/repository/queryset/post.py
@@ -30,11 +30,11 @@ class PostQuerySet(QuerySet):
     criteria and annotating posts with additional computed information.
     """
 
-    def filter_actives(self, is_active=True):
+    def filter_actives(self, is_published=True):
         """
         Returns a queryset of posts filtered by their active status.
         """
-        return self.filter(is_active=is_active)
+        return self.filter(is_published=is_published)
 
     def filter_recent_posts(self, num_posts=5, obj=None):
         """

--- a/sage_blog/repository/queryset/tag.py
+++ b/sage_blog/repository/queryset/tag.py
@@ -122,11 +122,11 @@ class TagQuerySet(QuerySet):
         qs = self.filter(posts__category__name=category_name).distinct()
         return qs
 
-    def exclude_inactive_posts(self) -> QuerySet:
+    def exclude_unpublished_posts(self) -> QuerySet:
         """
         Excludes tags that are only associated with inactive or discontinued posts.
         """
-        qs = self.filter(posts__is_active=True)
+        qs = self.filter(posts__is_published=True)
         return qs
 
     def sort_by_popularity(self) -> QuerySet:

--- a/sage_blog/views/mixins/context.py
+++ b/sage_blog/views/mixins/context.py
@@ -19,7 +19,7 @@ class SageBlogContextMixin(ContextMixin):
             self.recent_posts_limit
         )
         context[self.tags_context_name] = (
-            PostTag.dal.exclude_inactive_posts()
+            PostTag.dal.exclude_unpublished_posts()
             .annotate_total_posts()
             .filter_trend_tags(
                 days_ago=self.tags_days_ago,


### PR DESCRIPTION
- Replaced all instances of `is_active` with `is_published` in model admins and repositories.
- Added `published_posts_count` field in `sage_blog/admin/category.py` for `PostCategoryAdmin`.
- Renamed `post.py` to `category.py` in the `sage_blog/admin/filters/` directory.