### PR TITLE
test(repository): add unit tests for data access layer

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -591,6 +591,38 @@ files = [
 ]
 
 [[package]]
+name = "factory-boy"
+version = "3.3.1"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "factory_boy-3.3.1-py2.py3-none-any.whl", hash = "sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca"},
+    {file = "factory_boy-3.3.1.tar.gz", hash = "sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0"},
+]
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "mongomock", "mypy", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "27.0.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-27.0.0-py3-none-any.whl", hash = "sha256:55ed0c4ed7bf16800c64823805f6fbbe6d4823db4b7c0903f6f890b8e4d6c34b"},
+    {file = "faker-27.0.0.tar.gz", hash = "sha256:32c78b68d2ba97aaad78422e4035785de2b4bb46b81e428190fc11978da9036c"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "filelock"
 version = "3.15.4"
 description = "A platform independent file lock."
@@ -1384,6 +1416,38 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-django"
+version = "4.8.0"
+description = "A Django plugin for pytest."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-django-4.8.0.tar.gz", hash = "sha256:5d054fe011c56f3b10f978f41a8efb2e5adfc7e680ef36fb571ada1f24779d90"},
+    {file = "pytest_django-4.8.0-py3-none-any.whl", hash = "sha256:ca1ddd1e0e4c227cf9e3e40a6afc6d106b3e70868fd2ac5798a22501271cd0c7"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1645,6 +1709,17 @@ files = [
     {file = "ruff-0.5.7-py3-none-win_amd64.whl", hash = "sha256:083bbcbe6fadb93cd86709037acc510f86eed5a314203079df174c40bbbca6b3"},
     {file = "ruff-0.5.7-py3-none-win_arm64.whl", hash = "sha256:2dca26154ff9571995107221d0aeaad0e75a77b5a682d6236cf89a58c70b76f4"},
     {file = "ruff-0.5.7.tar.gz", hash = "sha256:8dfc0a458797f5d9fb622dd0efc52d796f23f0a1493a9527f4e49a550ae9a7e5"},
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 
 [[package]]
@@ -2021,4 +2096,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "16119f4674e149530b6bed647b0280e2ab721413c6c19bd4d80e399c27e85e1b"
+content-hash = "141c7ec693cefd45e9ae5256a793103499e6f328a23ec717ccf0acc7de08d83c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,14 @@ codecov = "^2.1.13"
 ruff = "^0.5.7"
 mypy = "^1.11.1"
 pylint-django = "^2.5.5"
+factory-boy = "^3.3.1"
+pytest-django = "^4.8.0"
 
 [tool.pytest.ini_options]
 addopts = "--cov=. --cov-report=term-missing --cov-report=html"
 DJANGO_SETTINGS_MODULE = "kernel.settings"
 python_files = ["tests.py", "test_*.py"]
-testpaths = ["tests"]
+testpaths = ["tests", "*/tests"]
 norecursedirs = [
     "migrations",
     "static",

--- a/sage_blog/repository/managers/post.py
+++ b/sage_blog/repository/managers/post.py
@@ -23,12 +23,12 @@ class PostDataAccessLayer(Manager):
         """
         return self.get_queryset().filter_actives(is_published)
 
-    def filter_recent_posts(self, num_posts=5):
+    def filter_recent_posts(self, num_posts=5, obj=None):
         """
         Retrieves a specified number of the most recently created posts.
         If 'obj' is provided, it excludes that object from the results.
         """
-        return self.get_queryset().filter_recent_posts(num_posts=num_posts)
+        return self.get_queryset().filter_recent_posts(num_posts=num_posts, obj=obj)
 
     def filter_by_category(self, category_slug):
         """
@@ -114,3 +114,16 @@ class PostDataAccessLayer(Manager):
 
     def join_tags(self):
         return self.get_queryset().join_tags()
+
+    def annotate_next_and_prev(self):
+        """
+        Annotates each post in the queryset with slugs of the next and previous posts
+        in the same category.
+
+        This method uses subqueries to determine the 'slug' of the
+        next and previous posts based on their primary key (pk)
+        within the same category. The result is the addition
+        of two new fields to each post object in the queryset:
+        `next_post_slug` and `prev_post_slug`.
+        """
+        return self.get_queryset().annotate_next_and_prev()

--- a/sage_blog/repository/managers/tag.py
+++ b/sage_blog/repository/managers/tag.py
@@ -87,11 +87,11 @@ class TagDataAccessLayer(Manager):
         """
         return self.get_queryset().search(search_term)
 
-    def filter_by_posts_category(self, category_name) -> QuerySet:
+    def filter_by_posts_category(self, category_title) -> QuerySet:
         """
         Filters tags based on the category of associated posts.
         """
-        return self.get_queryset().filter_by_posts_category(category_name)
+        return self.get_queryset().filter_by_posts_category(category_title)
 
     def exclude_unpublished_posts(self) -> QuerySet:
         """

--- a/sage_blog/repository/queryset/tag.py
+++ b/sage_blog/repository/queryset/tag.py
@@ -112,14 +112,14 @@ class TagQuerySet(QuerySet):
         """
         Performs a case-insensitive search for tags based on their name.
         """
-        qs = self.filter(name__icontains=search_term)
+        qs = self.filter(title__icontains=search_term)
         return qs
 
-    def filter_by_posts_category(self, category_name) -> QuerySet:
+    def filter_by_posts_category(self, category_title) -> QuerySet:
         """
         Filters tags based on the category of associated posts.
         """
-        qs = self.filter(posts__category__name=category_name).distinct()
+        qs = self.filter(posts__category__title=category_title).distinct()
         return qs
 
     def exclude_unpublished_posts(self) -> QuerySet:

--- a/sage_blog/tests/conftest.py
+++ b/sage_blog/tests/conftest.py
@@ -1,0 +1,42 @@
+# sage_blog/tests/conftest.py
+
+import pytest
+from .factories import PostCategoryFactory, PostTagFactory, PostFactory, PostFaqFactory
+
+@pytest.fixture
+def category():
+    return PostCategoryFactory()
+
+@pytest.fixture
+def tag():
+    return PostTagFactory()
+
+@pytest.fixture
+def post(category, tag):
+    return PostFactory(category=category, tags=[tag])
+
+@pytest.fixture
+def multiple_categories():
+    return PostCategoryFactory.create_batch(5)
+
+@pytest.fixture
+def multiple_tags():
+    return PostTagFactory.create_batch(10)
+
+@pytest.fixture
+def multiple_posts(multiple_categories, multiple_tags):
+    posts = []
+    for category in multiple_categories:
+        posts.append(PostFactory(category=category, tags=multiple_tags))
+    return posts
+
+@pytest.fixture
+def faq(post):
+    return PostFaqFactory(post=post)
+
+@pytest.fixture
+def multiple_faqs(multiple_posts):
+    faqs = []
+    for post in multiple_posts:
+        faqs.append(PostFaqFactory(post=post))
+    return faqs

--- a/sage_blog/tests/factories.py
+++ b/sage_blog/tests/factories.py
@@ -1,0 +1,50 @@
+import factory
+from django.utils.text import slugify
+from datetime import timezone
+
+from sage_blog.models import PostCategory, PostTag, Post, PostFaq
+
+class PostCategoryFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PostCategory
+
+    title = factory.Faker('word')
+    slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
+    is_published = factory.Faker('boolean', chance_of_getting_true=75)
+
+class PostTagFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PostTag
+
+    title = factory.Faker('word')
+    slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
+    is_published = factory.Faker('boolean', chance_of_getting_true=75)
+
+class PostFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Post
+
+    title = factory.Faker('sentence', nb_words=6)
+    slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
+    summary = factory.Faker('sentence', nb_words=12)
+    description = factory.Faker('text', max_nb_chars=200)
+    is_published = factory.Faker('boolean', chance_of_getting_true=75)
+    published_at = factory.Faker('date_time_this_decade', before_now=True, tzinfo=timezone.utc)
+    category = factory.SubFactory(PostCategoryFactory)
+
+    @factory.post_generation
+    def tags(self, create, extracted, **kwargs):
+        if not create:
+            return
+        
+        if extracted:
+            for tag in extracted:
+                self.tags.add(tag)
+
+class PostFaqFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PostFaq
+    
+    question = factory.Faker('sentence', nb_words=10)
+    answer = factory.Faker('paragraph', nb_sentences=3)
+    post = factory.SubFactory(PostFactory)

--- a/sage_blog/tests/repository/test_category_dal.py
+++ b/sage_blog/tests/repository/test_category_dal.py
@@ -1,0 +1,108 @@
+import pytest
+from datetime import timedelta
+from django.utils import timezone
+
+from ..factories import PostCategoryFactory, PostFactory
+from sage_blog.models import PostCategory
+
+@pytest.mark.django_db
+class TestCategoryQuerySet:
+
+    @pytest.fixture
+    def categories(self):
+        # Setup categories, some published and some not
+        return [
+            PostCategoryFactory(is_published=True),
+            PostCategoryFactory(is_published=False),
+            PostCategoryFactory(is_published=True),
+        ]
+
+    @pytest.fixture
+    def categories_with_posts(self):
+        # Setup categories with posts
+        category1 = PostCategoryFactory(is_published=True)
+        category2 = PostCategoryFactory(is_published=True)
+        category3 = PostCategoryFactory(is_published=False)
+
+        PostFactory.create_batch(5, category=category1, is_published=True)
+        PostFactory.create_batch(3, category=category2, is_published=False)
+        PostFactory.create_batch(0, category=category3)
+
+        return [category1, category2, category3]
+
+    def test_filter_published_categories(self, categories):
+        queryset = PostCategory.objects.filter_published(is_published=True)
+        assert queryset.count() == 2
+        for category in queryset:
+            assert category.is_published is True
+
+    def test_filter_unpublished_categories(self, categories):
+        queryset = PostCategory.objects.filter_published(is_published=False)
+        assert queryset.count() == 1
+        for category in queryset:
+            assert category.is_published is False
+
+    def test_filter_no_published_categories(self):
+        # Creating all categories as unpublished
+        PostCategory.objects.all().delete()
+        PostCategoryFactory.create_batch(3, is_published=False)
+
+        queryset = PostCategory.objects.filter_published(is_published=True)
+        assert queryset.count() == 0
+
+    def test_filter_published_posts_categories(self, categories_with_posts):
+        queryset = PostCategory.objects.filter_published_posts(is_published=True)
+        assert queryset.count() == 5
+        for category in queryset:
+            assert category.posts.filter(is_published=True).exists()
+
+    def test_filter_unpublished_posts_categories(self, categories_with_posts):
+        queryset = PostCategory.objects.filter_published_posts(is_published=False)
+        assert queryset.count() == 3
+        for category in queryset:
+            assert category.posts.filter(is_published=False).exists()
+
+
+    @pytest.mark.skip(reason="Performance test for large datasets, manually run if needed.")
+    def test_filter_published_posts_large_dataset(self):
+        # Creating a large dataset for performance testing
+        categories = PostCategoryFactory.create_batch(100)
+        for category in categories:
+            PostFactory.create_batch(100, category=category, is_published=True)
+        
+        queryset = PostCategory.objects.filter_published_posts(is_published=True)
+        assert queryset.count() == 100
+
+    def test_annotate_total_posts_varying(self, categories_with_posts):
+        queryset = PostCategory.objects.annotate_total_posts()
+        for category in queryset:
+            expected_count = category.posts.filter(is_published=True).count()
+            assert hasattr(category, 'total_posts')
+            assert category.total_posts == expected_count
+
+    def test_annotate_total_posts_no_posts(self):
+        empty_category = PostCategoryFactory()
+        queryset = PostCategory.objects.filter(id=empty_category.id).annotate_total_posts()
+        assert queryset.count() == 0
+
+    def test_annotate_total_posts_empty_category_list(self):
+        queryset = PostCategory.objects.none().annotate_total_posts()
+        assert queryset.count() == 0
+
+    def test_filter_recent_categories_various_values(self):
+        # Creating categories with different creation times
+        PostCategoryFactory(created_at=timezone.now() - timedelta(days=10))
+        PostCategoryFactory(created_at=timezone.now() - timedelta(days=5))
+        PostCategoryFactory(created_at=timezone.now() - timedelta(days=1))
+
+        queryset = PostCategory.objects.filter_recent_categories(num_categories=2)
+        assert queryset.count() == 2
+        assert queryset[0].created_at >= queryset[1].created_at  # Ensure they're ordered by recency
+
+    def test_filter_recent_categories_excluding_specific_category(self):
+        recent_category = PostCategoryFactory(created_at=timezone.now() - timedelta(days=1))
+        old_category = PostCategoryFactory(created_at=timezone.now() - timedelta(days=30))
+
+        queryset = PostCategory.objects.filter_recent_categories(num_categories=1, obj=recent_category)
+        assert queryset.count() == 1
+        assert old_category in queryset

--- a/sage_blog/tests/repository/test_post_dal.py
+++ b/sage_blog/tests/repository/test_post_dal.py
@@ -1,0 +1,298 @@
+import pytest
+from django.utils import timezone
+from django.conf import settings
+from datetime import timedelta
+
+from ..factories import PostFactory, PostCategoryFactory, PostTagFactory
+from sage_blog.models import Post
+
+
+@pytest.mark.django_db
+class TestPostQuerySet:
+
+    @pytest.fixture
+    def posts(self):
+        category1 = PostCategoryFactory(slug="category-1")
+        category2 = PostCategoryFactory(slug="category-2")
+        tag1 = PostTagFactory(slug="tag-1")
+        tag2 = PostTagFactory(slug="tag-2")
+
+        posts = [
+            PostFactory(is_published=True, category=category1, tags=[tag1]),
+            PostFactory(is_published=False, category=category1, tags=[tag2]),
+            PostFactory(is_published=True, category=category2, tags=[tag1]),
+            PostFactory(is_published=True, category=category2, tags=[tag2]),
+        ]
+        return posts
+
+    def test_filter_actives_all_published(self, posts):
+        queryset = Post.objects.filter_actives(is_published=True)
+        assert queryset.count() == 3
+
+    def test_filter_actives_all_unpublished(self, posts):
+        queryset = Post.objects.filter_actives(is_published=False)
+        assert queryset.count() == 1
+
+    def test_filter_actives_mix_published_unpublished(self, posts):
+        queryset_published = Post.objects.filter_actives(is_published=True)
+        queryset_unpublished = Post.objects.filter_actives(is_published=False)
+        assert queryset_published.count() == 3
+        assert queryset_unpublished.count() == 1
+
+    def test_filter_actives_empty_post_list(self):
+        queryset = Post.objects.all()
+        queryset = queryset.filter_actives(is_published=True)
+        assert queryset.count() == 0
+
+    def test_filter_recent_posts_fewer_than_num_posts(self, posts):
+        queryset = Post.objects.filter_recent_posts(num_posts=5)
+        assert queryset.count() == 4
+
+    def test_filter_recent_posts_exact_num_posts(self, posts):
+        queryset = Post.objects.filter_recent_posts(num_posts=3)
+        assert queryset.count() == 3
+
+    def test_filter_recent_posts_excluding_specific_post(self, posts):
+        specific_post = posts[0]
+        queryset = Post.objects.filter_recent_posts(num_posts=3, obj=specific_post)
+        assert queryset.count() == 3
+        assert specific_post not in queryset
+
+    def test_filter_recent_posts_empty_post_list(self):
+        queryset = Post.objects.none().filter_recent_posts(num_posts=3)
+        assert queryset.count() == 0
+
+    def test_filter_by_category_valid_slug(self, posts):
+        queryset = Post.objects.filter_by_category(category_slug=posts[0].category.slug)
+        assert queryset.count() == 2
+        for post in queryset:
+            assert post.category.slug == posts[0].category.slug
+
+    def test_filter_by_category_non_existent_slug(self):
+        queryset = Post.objects.filter_by_category(category_slug="non-existent")
+        assert queryset.count() == 0
+
+    def test_filter_by_tag_valid_slug(self, posts):
+        tags = [tag.slug for tag in posts[0].tags.all()]
+        queryset = Post.objects.filter_by_tag(tag_slug=tags[0])
+        assert queryset.count() == 2
+        for post in queryset:
+            assert any(tag.slug == tags[0] for tag in post.tags.all())
+
+    def test_filter_by_tag_non_existent_slug(self):
+        queryset = Post.objects.filter_by_tag(tag_slug="non-existent")
+        assert queryset.count() == 0
+
+    def test_filter_in_date_range_valid(self, posts):
+        start_date = timezone.now() - timedelta(days=1)
+        end_date = timezone.now() + timedelta(days=1)
+        queryset = Post.objects.filter_in_date_range(start_date, end_date)
+        assert queryset.count() == 4
+
+    def test_filter_in_date_range_no_posts_in_range(self, posts):
+        start_date = timezone.now() + timedelta(days=10)
+        end_date = timezone.now() + timedelta(days=20)
+        queryset = Post.objects.filter_in_date_range(start_date, end_date)
+        assert queryset.count() == 0
+
+    def test_filter_in_date_range_edge_cases(self, posts):
+        start_date = timezone.now() - timedelta(days=1)
+        end_date = timezone.now()
+        queryset = Post.objects.filter_in_date_range(start_date, end_date)
+        assert queryset.count() == 4
+
+    def test_annotate_total_tags_varying_numbers_of_tags(self, posts):
+        queryset = Post.objects.annotate_total_tags()
+        for post in queryset:
+            assert hasattr(post, 'tags_count')
+            assert post.tags_count == post.tags.count()
+
+    def test_annotate_total_tags_no_tags(self):
+        post = PostFactory(tags=[])
+        queryset = Post.objects.filter(id=post.id).annotate_total_tags()
+        assert queryset[0].tags_count == 0
+
+    def test_annotate_total_tags_empty_post_list(self):
+        queryset = Post.objects.none().annotate_total_tags()
+        assert queryset.count() == 0
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_heavy_search_exact_match(self, posts):
+        search_query = posts[0].title.split()[0]  # Search for the first word in the title
+        queryset = Post.objects.heavy_search(search_query)
+        assert queryset.count() >= 1
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_heavy_search_partial_match(self, posts):
+        search_query = posts[0].title[:3]  # Search for a partial match (first 3 chars)
+        queryset = Post.objects.heavy_search(search_query)
+        assert queryset.count() >= 1
+
+    def test_heavy_search_empty_query(self, posts):
+        queryset = Post.objects.heavy_search("")
+        assert queryset.count() == 4  # should return all posts or based on other filters
+
+    def test_join_category(self, posts):
+        queryset = Post.objects.join_category()
+        for post in queryset:
+            assert post.category is not None
+
+    def test_join_tags(self, posts):
+        queryset = Post.objects.join_tags()
+        for post in queryset:
+            assert post.tags.count() > 0
+
+    def test_join_category_no_categories(self):
+        queryset = Post.objects.none().join_category()
+        assert queryset.count() == 0
+
+    def test_join_tags_no_tags(self):
+        post = PostFactory(tags=[])
+        queryset = Post.objects.filter(id=post.id).join_tags()
+        assert queryset[0].tags.count() == 0
+
+    def test_filter_in_date_range_invalid_range(self, posts):
+        start_date = timezone.now() + timedelta(days=1)
+        end_date = timezone.now() - timedelta(days=1)
+        queryset = Post.objects.filter_in_date_range(start_date, end_date)
+        assert queryset.count() == 0
+
+    def test_filter_by_category_multiple_matches(self, posts):
+        queryset = Post.objects.filter_by_category(category_slug=posts[0].category.slug)
+        assert queryset.count() == 2
+
+    def test_filter_by_tag_multiple_matches(self, posts):
+        tags = [tag.slug for tag in posts[0].tags.all()]
+        queryset = Post.objects.filter_by_tag(tag_slug=tags[0])
+        assert queryset.count() == 2
+
+    def test_filter_new_posts_within_specified_days(self, posts):
+        queryset = Post.objects.filter_new_posts(days=7)
+        for post in queryset:
+            assert post.created_at >= timezone.now() - timedelta(days=7)
+
+    def test_annotate_published_since(self, posts):
+        queryset = Post.objects.annotate_published_since()
+        for post in queryset:
+            assert hasattr(post, 'days_since_published')
+            assert isinstance(post.days_since_published, timedelta)
+
+    def test_annotate_is_recent_within_7_days(self, posts):
+        queryset = Post.objects.annotate_is_recent()
+        for post in queryset:
+            if post.created_at >= timezone.now() - timedelta(days=7):
+                assert post.is_recent is True
+            else:
+                assert post.is_recent is False
+
+    def test_annotate_next_and_prev(self, posts):
+        queryset = Post.objects.annotate_next_and_prev()
+        for post in queryset:
+            if post.next_post_slug:
+                next_post = Post.objects.get(slug=post.next_post_slug)
+                assert next_post.pk > post.pk
+            if post.prev_post_slug:
+                prev_post = Post.objects.get(slug=post.prev_post_slug)
+                assert prev_post.pk < post.pk
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_full_text_search_exact_match(self, posts):
+        search_query = posts[0].title.split()[0]  # Search for the first word in the title
+        queryset = Post.objects.full_text_search(search_query)
+        assert queryset.count() >= 1
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_full_text_search_no_match(self):
+        search_query = "nonexistentword"
+        queryset = Post.objects.full_text_search(search_query)
+        assert queryset.count() == 0
+
+    def test_substring_search_partial_match(self, posts):
+        search_query = posts[0].title[:3]  # Search for a partial match (first 3 chars)
+        queryset = Post.objects.substring_search(search_query)
+        assert queryset.count() >= 1
+
+    def test_substring_search_no_match(self):
+        search_query = "nonexistentword"
+        queryset = Post.objects.substring_search(search_query)
+        assert queryset.count() == 0
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_trigram_similarity_search_close_match(self, posts):
+        search_query = posts[0].title[:3]  # Search for a trigram match (first 3 chars)
+        queryset = Post.objects.trigram_similarity_search(search_query)
+        assert queryset.count() >= 1
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_trigram_similarity_search_no_match(self):
+        search_query = "nonexistentword"
+        queryset = Post.objects.trigram_similarity_search(search_query)
+        assert queryset.count() == 0
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_heavy_search_combined_methods(self, posts):
+        search_query = posts[0].title.split()[0]  # Search for the first word in the title
+        queryset = Post.objects.heavy_search(search_query)
+        assert queryset.count() >= 1
+
+    @pytest.mark.skipif(
+        'sqlite3' in settings.DATABASES['default']['ENGINE'],
+        reason="These tests require PostgreSQL-specific features."
+    )
+    def test_heavy_search_no_match(self):
+        search_query = "nonexistentword"
+        queryset = Post.objects.heavy_search(search_query)
+        assert queryset.count() == 0
+
+    def test_heavy_search_empty_query(self, posts):
+        queryset = Post.objects.heavy_search("")
+        assert queryset.count() == 4  # should return all posts or based on other filters
+
+    @pytest.mark.skipif(
+        'postgresql' not in settings.DATABASES['default']['ENGINE'],
+        reason="This test requires PostgreSQL to execute trigram search."
+    )
+    def test_heavy_search_fallback_to_substring(self, posts):
+        # Full-text search should fail and fall back to substring search
+        search_query = "nonexistentword"
+        specific_word = posts[0].title[:3]  # A partial match to test fallback
+        queryset = Post.objects.heavy_search(specific_word)
+        assert queryset.count() >= 1
+
+    @pytest.mark.skipif(
+        'postgresql' in settings.DATABASES['default']['ENGINE'],
+        reason="This test is for databases other than PostgreSQL."
+    )
+    def test_trigram_similarity_search_non_postgresql(self):
+        search_query = "irrelevant"
+        queryset = Post.objects.trigram_similarity_search(search_query)
+        assert queryset.count() == 0  # Should return none for non-PostgreSQL databases
+
+    @pytest.mark.skipif(
+        'postgresql' in settings.DATABASES['default']['ENGINE'],
+        reason="This test is for databases other than PostgreSQL."
+    )
+    def test_full_text_search_no_query(self, posts):
+        queryset = Post.objects.full_text_search("")
+        assert queryset.count() == 4

--- a/sage_blog/tests/repository/test_tag_dal.py
+++ b/sage_blog/tests/repository/test_tag_dal.py
@@ -1,0 +1,112 @@
+import pytest
+from datetime import timedelta
+from django.utils import timezone
+from ..factories import PostTagFactory, PostFactory, PostCategoryFactory
+from sage_blog.models import PostTag
+
+@pytest.mark.django_db
+class TestTagQuerySet:
+
+    @pytest.fixture
+    def tags(self):
+        # Setup tags, some with associated posts, some without
+        tag1 = PostTagFactory()
+        tag2 = PostTagFactory()
+        tag3 = PostTagFactory()
+
+        category1 = PostCategoryFactory()
+        category2 = PostCategoryFactory()
+
+        PostFactory.create_batch(5, tags=[tag1], category=category1, is_published=True)
+        PostFactory.create_batch(3, tags=[tag2], category=category2, is_published=False)
+
+        return [tag1, tag2, tag3]
+
+    def test_filter_recent_tags_based_on_usage(self, tags):
+        queryset = PostTag.objects.filter_recent_tags(days_ago=30)
+        assert queryset.count() == 2  # Only tags with posts in the last 30 days should be returned
+
+    def test_filter_recent_tags_limit(self, tags):
+        queryset = PostTag.objects.filter_recent_tags(days_ago=30, limit=1)
+        assert queryset.count() == 1  # Limiting the number of tags returned
+
+    def test_filter_recent_tags_days_ago_zero(self, tags):
+        queryset = PostTag.objects.filter_recent_tags(days_ago=0)
+        assert queryset.count() == 3  # All tags should be returned
+
+    def test_filter_recent_tags_excluding_specific_tag(self, tags):
+        specific_tag = tags[0]
+        queryset = PostTag.objects.filter_recent_tags(days_ago=30, obj=specific_tag)
+        assert specific_tag not in queryset
+
+    def test_filter_trend_tags_based_on_usage(self, tags):
+        queryset = PostTag.objects.filter_trend_tags(days_ago=30, min_count=1)
+        assert queryset.count() == 2  # Tags with at least 1 associated post should be returned
+
+    def test_filter_trend_tags_min_count(self, tags):
+        queryset = PostTag.objects.filter_trend_tags(days_ago=30, min_count=5)
+        assert queryset.count() == 1  # Only tag with at least 5 posts should be returned
+
+    def test_filter_trend_tags_limit(self, tags):
+        queryset = PostTag.objects.filter_trend_tags(days_ago=30, limit=1)
+        assert queryset.count() == 1  # Limiting the number of tags returned
+
+    def test_search_case_insensitive(self, tags):
+        search_term = tags[0].title.lower()
+        queryset = PostTag.objects.search(search_term)
+        assert queryset.count() == 1
+        assert queryset[0].title.lower() == search_term
+
+    def test_search_exact_match(self, tags):
+        search_term = tags[0].title
+        queryset = PostTag.objects.search(search_term)
+        assert queryset.count() == 1
+        assert queryset[0].title == search_term
+
+    def test_search_partial_match(self, tags):
+        search_term = tags[0].title[:3]  # Partial match on the first 3 characters
+        queryset = PostTag.objects.search(search_term)
+        assert queryset.count() >= 1
+
+    def test_search_special_characters_or_empty_search(self):
+        special_character_search = "@!#"
+        empty_search = ""
+        queryset_special_characters = PostTag.objects.search(special_character_search)
+        queryset_empty_search = PostTag.objects.search(empty_search)
+        assert queryset_special_characters.count() == 0  # Should return none
+        assert queryset_empty_search.count() >= 0  # Depending on implementation, may return all tags
+
+    def test_filter_by_posts_category_valid(self, tags):
+        category = tags[0].posts.first().category
+        queryset = PostTag.objects.filter_by_posts_category(category_title=category.title)
+        assert queryset.count() == 1
+        assert tags[0] in queryset
+
+    def test_filter_by_posts_category_no_tags(self):
+        category = PostCategoryFactory()  # Category with no associated tags
+        queryset = PostTag.objects.filter_by_posts_category(category_title=category.title)
+        assert queryset.count() == 0
+
+    def test_filter_by_posts_category_non_existent(self):
+        queryset = PostTag.objects.filter_by_posts_category(category_title="non-existent")
+        assert queryset.count() == 0
+
+    def test_sort_by_popularity(self, tags):
+        queryset = PostTag.objects.sort_by_popularity()
+        assert queryset.first().posts.count() >= queryset.last().posts.count()
+
+    def test_sort_by_popularity_same_popularity(self):
+        # Create tags with the same number of posts
+        tag1 = PostTagFactory()
+        tag2 = PostTagFactory()
+        PostFactory.create_batch(2, tags=[tag1])
+        PostFactory.create_batch(2, tags=[tag2])
+
+        queryset = PostTag.objects.filter(id__in=[tag1.id, tag2.id]).sort_by_popularity()
+        assert queryset.count() == 2
+        assert queryset[0].posts.count() == queryset[1].posts.count()
+
+    def test_sort_by_popularity_no_posts(self, tags):
+        tag_with_no_posts = tags[2]  # This tag was created without posts
+        queryset = PostTag.objects.sort_by_popularity()
+        assert queryset.last() == tag_with_no_posts


### PR DESCRIPTION
- Added unit tests for the data access layer in `sage_blog/tests/repository/`.
- Created test files: `test_category_dal.py`, `test_post_dal.py`, `test_tag_dal.py`.
- Added test utilities: `conftest.py`, `factories.py`.
- Ensured coverage for `Category`, `Post`, and `Tag` data access logic.

closes #12