### PR TITLE
feat(settings-checks): add validation for required settings in settin…

### DIFF
--- a/sage_blog/settings/check.py
+++ b/sage_blog/settings/check.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.core.checks import Error
-from django.core.checks import Warning as CheckWarning
+from django.core.checks import Error, Warning as CheckWarning
 from django.core.checks import register
 from django.db import OperationalError, connection
 
@@ -10,7 +9,7 @@ def check_postgres_extensions(app_configs, **_kwargs):
     errors = []
     warnings = []
 
-    # Dynamically check the database engine
+    # Check the DATABASE engine
     database_engine = settings.DATABASES["default"]["ENGINE"]
     if "postgresql" in database_engine:
         try:
@@ -21,10 +20,7 @@ def check_postgres_extensions(app_configs, **_kwargs):
                     errors.append(
                         Error(
                             "pg_trgm extension is not installed",
-                            hint=(
-                                "Run `CREATE EXTENSION pg_trgm;` in "
-                                "your PSQL database."
-                            ),
+                            hint="Run `CREATE EXTENSION pg_trgm;` in your PSQL database.",
                             id="postgres.E001",
                         )
                     )
@@ -40,11 +36,63 @@ def check_postgres_extensions(app_configs, **_kwargs):
         warnings.append(
             CheckWarning(
                 "Database engine is not PostgreSQL.",
-                hint=(
-                    "PostgreSQL improves search in `django-sage-blog`, "
-                    "but it's optional."
-                ),
+                hint="PostgreSQL improves search in `django-sage-blog`, but it's optional.",
                 id="postgres.W001",
+            )
+        )
+
+    return errors + warnings
+
+@register()
+def check_required_settings(app_configs, **_kwargs):
+    errors = []
+    warnings = []
+
+    # Check LANGUAGE_CODE
+    if not hasattr(settings, "LANGUAGE_CODE"):
+        errors.append(
+            Error(
+                "LANGUAGE_CODE setting is missing.",
+                hint="Add LANGUAGE_CODE in your settings file.",
+                id="settings.E001",
+            )
+        )
+    
+    # Check LANGUAGES
+    if not hasattr(settings, "LANGUAGES"):
+        errors.append(
+            Error(
+                "LANGUAGES setting is missing.",
+                hint="Add LANGUAGES in your settings file.",
+                id="settings.E002",
+            )
+        )
+
+    # Check CKEDITOR_5_STORAGE_BACKEND
+    if not hasattr(settings, "CKEDITOR_5_STORAGE_BACKEND"):
+        errors.append(
+            Error(
+                "CKEDITOR_5_STORAGE_BACKEND setting is missing.",
+                hint="Add CKEDITOR_5_STORAGE_BACKEND in your settings file.",
+                id="settings.E003",
+            )
+        )
+
+    # Check MODELTRANSLATION_CUSTOM_FIELDS
+    if not hasattr(settings, "MODELTRANSLATION_CUSTOM_FIELDS"):
+        errors.append(
+            Error(
+                "MODELTRANSLATION_CUSTOM_FIELDS setting is missing.",
+                hint="Add MODELTRANSLATION_CUSTOM_FIELDS in your settings file.",
+                id="settings.E004",
+            )
+        )
+    elif settings.MODELTRANSLATION_CUSTOM_FIELDS != "django_ckeditor_5.fields.CKEditor5Field":
+        errors.append(
+            Error(
+                "MODELTRANSLATION_CUSTOM_FIELDS is not set to 'django_ckeditor_5.fields.CKEditor5Field'.",
+                hint="Set MODELTRANSLATION_CUSTOM_FIELDS to 'django_ckeditor_5.fields.CKEditor5Field' in your settings file.",
+                id="settings.E005",
             )
         )
 


### PR DESCRIPTION
…gs.py

- Added check for PostgreSQL pg_trgm extension and warnings for non-PostgreSQL databases.
- Introduced validation for the following settings:
  - LANGUAGE_CODE: Raises error if missing from settings.py.
  - LANGUAGES: Raises error if missing from settings.py.
  - CKEDITOR_5_STORAGE_BACKEND: Raises error if not defined in settings.py.
  - MODELTRANSLATION_CUSTOM_FIELDS: Validates that this setting is present and correctly set to 'django_ckeditor_5.fields.CKEditor5Field', otherwise raises an error.